### PR TITLE
fix: 支持升级到3.2.0后的版本

### DIFF
--- a/autotracker-upgrade-2to3-cdp/src/main/java/com/growingio/android/sdk/collection/GrowingIO.java
+++ b/autotracker-upgrade-2to3-cdp/src/main/java/com/growingio/android/sdk/collection/GrowingIO.java
@@ -24,10 +24,10 @@ import android.content.SharedPreferences;
 import android.text.TextUtils;
 import android.util.Log;
 
+import com.growingio.android.sdk.TrackerContext;
 import com.growingio.android.sdk.autotrack.GrowingAutotracker;
 import com.growingio.android.sdk.autotrack.hybrid.event.HybridPageEvent;
 import com.growingio.android.sdk.interfaces.IGrowingIO;
-import com.growingio.android.sdk.track.ContextProvider;
 import com.growingio.android.sdk.track.TrackMainThread;
 import com.growingio.android.sdk.track.data.PersistentDataProvider;
 import com.growingio.android.sdk.track.utils.JsonUtil;
@@ -70,7 +70,7 @@ public class GrowingIO implements IGrowingIO {
      * 需要在初始化前调用, 将userId以及deviceId从v2版本迁移到v3版本中
      */
     public void upgrade(Application context) {
-        ContextProvider.setContext(context);
+        TrackerContext.init(context);
         if (PersistentDataProvider.get().getString(KEEP_ID, null) == null) {
             upgradeDeviceId(context);
             upgradeUserId(context);

--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ buildscript {
         ]
 
         releaseConfiguration = [
-                releaseVersion    : "1.0.0",
-                releaseVersionCode: 10000,
+                releaseVersion    : "3.2.0", // 支持升级到3.2.0之后的版本
+                releaseVersionCode: 30200,
         ]
 
         libraries = [
@@ -29,8 +29,8 @@ buildscript {
                 'growingio': [
                         'tracker_cdp_v2'    : 'com.growingio.android:vds-android-agent:cdp-1.2.4',
 
-                        'tracker_cdp_v3'    : "com.growingio.android:tracker-cdp:3.0.0",
-                        'autotracker_cdp_v3': "com.growingio.android:autotracker-cdp:3.0.0",
+                        'tracker_cdp_v3'    : "com.growingio.android:tracker-cdp:3.2.1-SNAPSHOT",
+                        'autotracker_cdp_v3': "com.growingio.android:autotracker-cdp:3.2.1-SNAPSHOT",
                 ],
         ]
     }


### PR DESCRIPTION
Context的设置在3.2.0修改了, 将upgrade版本号变为支持的埋点的版本号, 如3.2.0表示支持升级到埋点3.2.0+的版本
测试: 通过先集成2.0的cdp版本, 调用GrowingIO.getInstance().setUserId("styluo"); 通过vst事件日志记录cs1和u
改为集成3.0的cdp版本, 替换对应初始化方法, 通过vst事件比对deviceId和u, userId和cs1是否相同